### PR TITLE
Re-add context to macros hack after upgrade/sync

### DIFF
--- a/src/jinja2/compiler.py
+++ b/src/jinja2/compiler.py
@@ -659,8 +659,14 @@ class CodeGenerator(NodeVisitor):
         # macros are delayed, they never require output checks
         frame.require_output_check = False
         frame.symbols.analyze_node(node)
-        self.writeline(f"{self.func('macro')}({', '.join(args)}):", node)
+        self.writeline('outer_context = context')
+        self.writeline('%s(%s):' %
+                       (self.func('macro'), ', '.join(['context'] + args)),
+                       node)
         self.indent()
+        self.writeline('nonlocal outer_context')
+        self.writeline('context = context or outer_context')
+        self.writeline('resolve = context.resolve_or_missing')
 
         self.buffer(frame)
         self.enter_frame(frame)


### PR DESCRIPTION
I changed the upstream to track the original Jinja repo (at pallets), but they changed their default branch to main. So I branched off that and re-added the fix. There's probably a neater way to do this but I don't have full permissions of this repo. 